### PR TITLE
Closes #85 . Added functionality for nett balance in date range

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,6 @@ import sys
 sys.path.insert(0, "..\\src\\domain")
 sys.path.insert(0, "..\\src\\services")
 
-from file_handler import FileHandler
 from controller import Controller
 from svmclassifier import SVMClassifier
 
@@ -13,8 +12,9 @@ classification_csv_file = "../data/classified_transactions.csv"
 classifier = SVMClassifier()
 controller = Controller(classifier, db_name, classification_csv_file)
 
-controller.seed_database("../data/seed_file.csv")
-controller.get_new_transactions("../data/transactions.csv")
-controller.classify_new_transactions()
-print(classifier.get_name(), classifier.get_train_accuracy())
-print(controller.confirm_csv_classification())
+# controller.seed_database("../data/seed_file.csv")
+# controller.get_new_transactions("../data/transactions.csv")
+# controller.classify_new_transactions()
+# print(classifier.get_name(), classifier.get_train_accuracy())
+# print(controller.confirm_csv_classification())
+print(controller.get_nett_balance("2015-01-19", "2015-01-26"))

--- a/src/domain/controller.py
+++ b/src/domain/controller.py
@@ -44,5 +44,9 @@ class Controller:
 
     def confirm_csv_classification(self):
         df = self.handler.read_classified_csv(self.class_csv)
-        # df["Labels"] = df["Labels"].astype("int32").astype("str")
         return self.data.persist_classified(df)
+
+    def get_nett_balance(self, start, end):
+        df = self.data.get_range("transactions", start, end)
+        return sum(df["Amount"].astype(float) * df["Labels"].astype(int))
+

--- a/src/services/database.py
+++ b/src/services/database.py
@@ -55,6 +55,12 @@ class Data:
     def get_unclassified(self):
         return self.__get_records(collection=self._unclassified)
 
+    def get_range(self, collection, start, end):
+        df = pd.DataFrame(self._db[collection].find({}))
+        df = df[df["Date"] >= start]
+        df = df[df["Date"] <= end]
+        return df
+
     def persist_classified(self, records):
         return self.__persist_records(collection=self._classified, records=records)
 

--- a/unit_tests/test_domain_controller.py
+++ b/unit_tests/test_domain_controller.py
@@ -46,6 +46,15 @@ class ControllerTests(unittest.TestCase):
 
         self.assertRaises(KeyError, controller.seed_database, self.incorrect_seed)
 
+    def test_get_nett_balance_on_execute_returns_correct_balance(self):
+        self.db["transactions"].delete_many({})
+        controller = Controller(SVMClassifier(), self.db_name, "")
+        controller.seed_database(file_name=self.seed_file)
+
+        result = round(controller.get_nett_balance("2015-01-19", "2015-01-26"), 2)
+
+        self.assertEqual(-7095.81, result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Reference a related issue
This pull request Closes #85 


Added functionality to return nett balance of
budget transactions between a start and end date
both included.

Changes to be committed:
	modified:   src/app.py
	modified:   src/domain/controller.py
	modified:   src/services/database.py
	modified:   unit_tests/test_domain_controller.py



